### PR TITLE
attempt to extend API functionality

### DIFF
--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -1,0 +1,53 @@
+name: Docker CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}${{ env.TAG }}
+          tags: |
+            type=raw,value=1.0.${{ github.run_number }},priority=1000
+            type=ref,event=branch
+            type=sha
+            type=raw,value=latest
+
+      - name: Log in to ghcr
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: startsWith(github.ref, 'refs/heads/main')
+        run: echo "TAG=latest" >> $GITHUB_ENV
+
+      - if: startsWith(github.ref, 'refs/tags')
+        run: echo "TAG=$(git describe --tags)" >> $GITHUB_ENV
+
+      - name: Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -15,10 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
       - name: checkout code
         uses: actions/checkout@v2
 
+      # this is a little bit of "dark magick"...
+      # Github Registry seems to hate Usernames Containing UpperCase...
+      #
+      # this metadata action normalizes the image tags into something useable.
+      # I'm not sure it's the _best_ set of Docker Tags to use.
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -38,7 +42,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - if: startsWith(github.ref, 'refs/heads/main')
+      - if: startsWith(github.ref, 'refs/heads/master')
         run: echo "TAG=latest" >> $GITHUB_ENV
 
       - if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/docker-cd.yml
+++ b/.github/workflows/docker-cd.yml
@@ -3,7 +3,7 @@ name: Docker CD
 on:
   push:
     branches:
-      - main
+      - master
     tags:
       - '*'
     paths-ignore:

--- a/HueLightDJ.Web/Controllers/ApiController.cs
+++ b/HueLightDJ.Web/Controllers/ApiController.cs
@@ -12,6 +12,12 @@ namespace HueLightDJ.Web.Controllers
   [ApiController]
   public class ApiController : ControllerBase
   {
+    [HttpPost("setbpm")]
+    public void SetBPM([FromBody]double bpm)
+    {
+      ManualControlService.SetBPM(bpm);
+    }
+
     [HttpPost("setcolors")]
     public void SetColors([FromBody]string[,] matrix)
     {

--- a/HueLightDJ.Web/Controllers/ApiController.cs
+++ b/HueLightDJ.Web/Controllers/ApiController.cs
@@ -36,10 +36,11 @@ namespace HueLightDJ.Web.Controllers
       EffectService.StartAutoMode();
     }
 
-    [HttpPost("stop-auto")]
+    [HttpPost("stop-all")]
     public void StopAuto()
     {
       EffectService.StopAutoMode();
+      EffectService.StopEffects();
     }
 
     [HttpPost("test")]

--- a/HueLightDJ.Web/Controllers/ApiController.cs
+++ b/HueLightDJ.Web/Controllers/ApiController.cs
@@ -15,7 +15,7 @@ namespace HueLightDJ.Web.Controllers
     [HttpPost("setbpm")]
     public void SetBPM([FromBody]double bpm)
     {
-      ManualControlService.SetBPM(bpm);
+      StreamingSetup.SetBPM(bpm);
     }
 
     [HttpPost("setcolors")]

--- a/HueLightDJ.Web/Controllers/ApiController.cs
+++ b/HueLightDJ.Web/Controllers/ApiController.cs
@@ -13,7 +13,7 @@ namespace HueLightDJ.Web.Controllers
   public class ApiController : ControllerBase
   {
     [HttpPost("setbpm")]
-    public void SetBPM([FromBody]double bpm)
+    public void SetBPM([FromBody]int bpm)
     {
       StreamingSetup.SetBPM(bpm);
     }

--- a/HueLightDJ.Web/Controllers/ApiController.cs
+++ b/HueLightDJ.Web/Controllers/ApiController.cs
@@ -30,6 +30,18 @@ namespace HueLightDJ.Web.Controllers
       EffectService.Beat(intensity);
     }
 
+    [HttpPost("start-auto")]
+    public void StartAuto()
+    {
+      EffectService.StartAutoMode();
+    }
+
+    [HttpPost("stop-auto")]
+    public void StopAuto()
+    {
+      EffectService.StopAutoMode();
+    }
+
     [HttpPost("test")]
     public void Test([FromBody]string test)
     {

--- a/HueLightDJ.Web/Streaming/ManualControlService.cs
+++ b/HueLightDJ.Web/Streaming/ManualControlService.cs
@@ -9,12 +9,6 @@ namespace HueLightDJ.Web.Streaming
 {
   public static class ManualControlService
   {
-    public static void SetBPM(int bpm)
-    {
-      BPM = bpm;
-      WaitTime.Value = TimeSpan.FromMilliseconds((60 * 1000) / bpm);
-    }
-
     public static void SetColors(string[,] matrix)
     {
       var heightIndex = matrix.GetUpperBound(0);

--- a/HueLightDJ.Web/Streaming/ManualControlService.cs
+++ b/HueLightDJ.Web/Streaming/ManualControlService.cs
@@ -9,6 +9,12 @@ namespace HueLightDJ.Web.Streaming
 {
   public static class ManualControlService
   {
+    public static void SetBPM(int bpm)
+    {
+      BPM = bpm;
+      WaitTime.Value = TimeSpan.FromMilliseconds((60 * 1000) / bpm);
+    }
+
     public static void SetColors(string[,] matrix)
     {
       var heightIndex = matrix.GetUpperBound(0);


### PR DESCRIPTION
`start-auto` and `stop-all` work as intended. I considered namespacing them under `/api/auto` but I didn't feel like getting overly entangled for my first dotnet PR. I'll gladly clean up or rename things as you desire.

example of poking it with curl:

```
curl -vvv --header 'Content-Type: application/json' http://my.docker.host:8080/api/stop-all -X POST -d ''
```

---

`setbpm` does **not** do what I expect if I have a Browser window open. I suspect the usage of `StreamingSetup` is causing some kind of resource conflict / disagreement.

similarly, I didn't see an obvious way to fire any kind of `Connect()` method. the application already supports Complex Configs with multiple realms, so I assumed the API command would need to take a `name` parameter. (Personally I wouldn't mind `start-auto` doing a Connect but that assumes Only One connection)

I'd love even the faintest hint or documentation RTFM so I can make `/api/{connect,disconnect,setbpm}`. I think I might also want an API call for "HSB Loop Effect". I suspect I will need to add code to the `ManualControlService` but I'd _like_ to re-use as much of the existing code-paths as possible.

---
(also included is a Github Workflow to build Docker Images, I nuke that entirely or break into it's own PR if you'd like)